### PR TITLE
Remove --socket=fallback-x11

### DIFF
--- a/org.clementine_player.Clementine.yaml
+++ b/org.clementine_player.Clementine.yaml
@@ -8,7 +8,7 @@ rename-icon: clementine
 # rename-appdata-file: clementine.appdata.xml # Enable once in upstream
 finish-args:
   - --share=ipc
-  - --socket=fallback-x11
+  - --socket=x11
   - --socket=wayland
   - --socket=pulseaudio
   - --device=dri


### PR DESCRIPTION
It seems that `--socket=fallback-x11` will not work on Gnome with KDE runitme apps. Replace it with regular `--socket=x11`.