### PR TITLE
Add Last.fm support

### DIFF
--- a/org.clementine_player.Clementine.yaml
+++ b/org.clementine_player.Clementine.yaml
@@ -19,7 +19,7 @@ finish-args:
   - --filesystem=/run/media
   - --system-talk-name=org.freedesktop.Avahi
   - --talk-name=org.freedesktop.Notifications
-  - --talk-name=org.freedesktop.UDisks2
+  - --system-talk-name=org.freedesktop.UDisks2
   - --talk-name=org.gnome.SettingsDaemon.MediaKeys
   - --talk-name=org.wiimotedev.deviceEvents
   - --talk-name=org.mpris.MediaPlayer2.Player

--- a/org.clementine_player.Clementine.yaml
+++ b/org.clementine_player.Clementine.yaml
@@ -140,6 +140,29 @@ modules:
         url: https://github.com/sparsehash/sparsehash/archive/sparsehash-2.0.3.tar.gz
         sha256: 05e986a5c7327796dad742182b2d10805a8d4f511ad090da0490f146c1ff7a8c
 
+  - name: liblastfm
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: "https://github.com/lastfm/liblastfm.git"
+        tag: "1.1.0"
+    modules:
+
+      - name: fftw3
+        buildsystem: cmake-ninja
+        config-opts:
+          - -DENABLE_FLOAT=ON
+        build-options:
+          arch:
+            x86_64:
+              config-opts:
+                - -DENABLE_SSE2=ON
+                - -DENABLE_AVX=ON
+        sources:
+          - type: archive
+            url: "http://fftw.org/fftw-3.3.8.tar.gz"
+            sha256: 6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303
+
   - name: clementine
     builddir: true
     buildsystem: cmake-ninja

--- a/org.clementine_player.Clementine.yaml
+++ b/org.clementine_player.Clementine.yaml
@@ -143,9 +143,9 @@ modules:
   - name: liblastfm
     buildsystem: cmake-ninja
     sources:
-      - type: git
-        url: "https://github.com/lastfm/liblastfm.git"
-        tag: "1.1.0"
+      - type: archive
+        url: "https://github.com/lastfm/liblastfm/archive/1.1.0.tar.gz"
+        sha256: f61f0daa384e081a8f2bd2f7a2148babff22696e5b72ecdac86940a10100b1c8
     modules:
 
       - name: fftw3


### PR DESCRIPTION
liblastfm requires fftw3, which has multiple build options with different precision. I'm not sure which should be used for the best results, so picked the default one.
Fixes #20 