### PR TITLE
Runtime & dependencies update

### DIFF
--- a/org.clementine_player.Clementine.yaml
+++ b/org.clementine_player.Clementine.yaml
@@ -45,8 +45,8 @@ modules:
       - cp -r boost "${FLATPAK_DEST}/include/boost"
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.bz2
-        sha256: fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854
+        url: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2
+        sha256: 8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
         x-checker-data:
           type: anitya
           project-id: 6845
@@ -59,8 +59,8 @@ modules:
       - --with-pic
     sources:
       - type: archive
-        url: https://github.com/protocolbuffers/protobuf/archive/v3.19.0.tar.gz
-        sha256: 4a045294ec76cb6eae990a21adb5d8b3c78be486f1507faa601541d1ccefbd6b
+        url: https://github.com/protocolbuffers/protobuf/archive/v3.19.1.tar.gz
+        sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
         x-checker-data:
           type: anitya
           project-id: 3715
@@ -76,8 +76,8 @@ modules:
       - -DBUILD_SHARED_LIBS=ON
     sources:
       - type: archive
-        url: https://github.com/acoustid/chromaprint/releases/download/v1.5.0/chromaprint-1.5.0.tar.gz
-        sha256: 573a5400e635b3823fc2394cfa7a217fbb46e8e50ecebd4a61991451a8af766a
+        url: https://github.com/acoustid/chromaprint/releases/download/v1.5.1/chromaprint-1.5.1.tar.gz
+        sha256: a1aad8fa3b8b18b78d3755b3767faff9abb67242e01b478ec9a64e190f335e1c
         x-checker-data:
           type: anitya
           project-id: 286

--- a/org.clementine_player.Clementine.yaml
+++ b/org.clementine_player.Clementine.yaml
@@ -1,6 +1,6 @@
 app-id: org.clementine_player.Clementine
 runtime: org.kde.Platform
-runtime-version: '5.15'
+runtime-version: '5.15-21.08'
 sdk: org.kde.Sdk
 command: clementine
 finish-args:

--- a/org.clementine_player.Clementine.yaml
+++ b/org.clementine_player.Clementine.yaml
@@ -186,14 +186,9 @@ modules:
   - name: liblastfm
     buildsystem: cmake-ninja
     sources:
-      - type: archive
-        url: https://github.com/lastfm/liblastfm/archive/1.1.0.tar.gz
-        sha256: f61f0daa384e081a8f2bd2f7a2148babff22696e5b72ecdac86940a10100b1c8
-        x-checker-data:
-          type: anitya
-          project-id: 1651
-          stable-only: true
-          url-template: https://github.com/lastfm/liblastfm/archive/$version.tar.gz
+      - type: git
+        url: https://github.com/lastfm/liblastfm.git
+        commit: 2ce2bfe1879227af8ffafddb82b218faff813db9
 
   - name: clementine
     builddir: true


### PR DESCRIPTION
* Update to the 5.15 KDE Runtime (based on Freedesktop 21.08 Runtime)
* Update dependencies

Replaces https://github.com/flathub/org.clementine_player.Clementine/pull/38, https://github.com/flathub/org.clementine_player.Clementine/pull/39, https://github.com/flathub/org.clementine_player.Clementine/pull/41, https://github.com/flathub/org.clementine_player.Clementine/pull/42, https://github.com/flathub/org.clementine_player.Clementine/pull/43.