### PR TITLE
Disable x-checker until maintenance resumes

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "skip-arches": ["arm"]
+  "disable-external-data-checker": true
 }

--- a/org.clementine_player.Clementine.appdata.xml
+++ b/org.clementine_player.Clementine.appdata.xml
@@ -14,6 +14,9 @@
 	<summary xml:lang="id">Pemutar musik</summary>
 	<description>
 		<p>Clementine is a multiplatform music player. It is inspired by Amarok 1.4, focusing on a fast and easy-to-use interface for searching and playing your music.</p>
+		<p xml:lang="pt_BR">Clementine é um player de músicas multiplataforma Ele é inspirado no Amarok 1.4, focado em uma interface fácil de usar e rápida para procurar e tocar sua música.</p>
+		<p xml:lang="es"> Clementine es un reproductor musical multiplataforma. Está inspirado en Amarok 1.4, y se enfoca en una interfaz rápida y fácil de usar para buscar y reproducir su música.</p>
+		<p xml:lang="id">Clementine adalah pemutar musik multiplatfom. Terinspirasi oleh Amarok 1.4, berfokus pada antarmuka cepat dan mudah digunakan untuk mencari dan memutar musik Anda.</p>
 		<ul>
 			<li>Search and play your local music library</li>
 			<li>Listen to internet radio from Spotify, Grooveshark, SomaFM, Magnatune, Jamendo, SKY.fm, Digitally Imported, JAZZRADIO.com, Soundcloud, Icecast and Subsonic servers</li>
@@ -36,9 +39,6 @@
 			<li>Queue manager</li>
 		</ul>
 	</description>
-	<description xml:lang="pt_BR"><p>Clementine é um player de músicas multiplataforma Ele é inspirado no Amarok 1.4, focado em uma interface fácil de usar e rápida para procurar e tocar sua música.</p></description>
-	<description xml:lang="es"><p> Clementine es un reproductor musical multiplataforma. Está inspirado en Amarok 1.4, y se enfoca en una interfaz rápida y fácil de usar para buscar y reproducir su música.</p></description>
-	<description xml:lang="id"><p>Clementine adalah pemutar musik multiplatfom. Terinspirasi oleh Amarok 1.4, berfokus pada antarmuka cepat dan mudah digunakan untuk mencari dan memutar musik Anda.</p></description>
 	<url type="homepage">https://www.clementine-player.org</url>
 	<url type="bugtracker">https://github.com/clementine-player/Clementine/issues</url>
 	<url type="translate">https://www.transifex.com/davidsansome/clementine</url>

--- a/org.clementine_player.Clementine.yaml
+++ b/org.clementine_player.Clementine.yaml
@@ -208,6 +208,8 @@ modules:
         tag: 1.4.0rc1-697-gcddc08e14
         commit: cddc08e148e77a91b6afe3cf0d5306519052a177
       - type: patch
+        path: patches/icon-size.patch
+      - type: patch
         path: patches/clementine.save_playlists_to_xdg-config-home.patch
       - type: file
         path: org.clementine_player.Clementine.appdata.xml

--- a/patches/icon-size.patch
+++ b/patches/icon-size.patch
@@ -1,0 +1,25 @@
+From 807d7f80b38bebdab886ed99dd0ce88cc06fdae3 Mon Sep 17 00:00:00 2001
+From: bbhtt <bbhtt.zn0i8@slmail.me>
+Date: Sun, 3 Mar 2024 12:24:54 +0530
+Subject: [PATCH] Make icon square
+
+---
+ data/icon.svg | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/icon.svg b/data/icon.svg
+index d77d513dc..1bb25175b 100644
+--- a/data/icon.svg
++++ b/data/icon.svg
+@@ -11,7 +11,7 @@
+    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+    width="43.521561"
+-   height="38.635509"
++   height="43.521561"
+    id="svg2843"
+    version="1.1"
+    inkscape:version="0.47 r22583"
+-- 
+2.44.0
+


### PR DESCRIPTION
Last activity on the repo was 2 years ago https://github.com/flathub/org.clementine_player.Clementine/commit/79b8cba2803d879c3adef63bf2ba5e020de47940 while x-checker PRs are piling up and wasting resources.

So disable it until maintenance resumes