### PR TITLE
Update runtime to 5.15-24.08, fix Boost URL and update Boost to 1.89.0

### DIFF
--- a/org.clementine_player.Clementine.yaml
+++ b/org.clementine_player.Clementine.yaml
@@ -1,6 +1,6 @@
 app-id: org.clementine_player.Clementine
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-24.08
 sdk: org.kde.Sdk
 command: clementine
 finish-args:
@@ -45,13 +45,13 @@ modules:
       - cp -r boost "${FLATPAK_DEST}/include/boost"
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2
-        sha256: 475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39
+        url: https://archives.boost.io/release/1.89.0/source/boost_1_89_0.tar.bz2
+        sha256: 85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a
         x-checker-data:
           type: anitya
           project-id: 6845
           stable-only: true
-          url-template: https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2
+          url-template: https://archives.boost.io/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2
 
   - name: protobuf
     config-opts:


### PR DESCRIPTION
Replaces #132 and #135