### PR TITLE
Drop libusb module

### DIFF
--- a/org.clementine_player.Clementine.yaml
+++ b/org.clementine_player.Clementine.yaml
@@ -36,7 +36,6 @@ modules:
   - shared-modules/glew/glew.json
   - shared-modules/glu/glu-9.json
   - shared-modules/linux-audio/fftw3f.json
-  - shared-modules/libusb/libusb.json
   - name: libmtp
     config-opts:
       - --disable-static


### PR DESCRIPTION
libusb is part of the runtime 5.15-25.08 and 6.10

Fixes: https://github.com/flathub/org.clementine_player.Clementine/issues/156